### PR TITLE
Fix/loading player

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What?
 
-Logging login players and logout players
+Logging login players and logout players.
 
 # Spec
 

--- a/app.py
+++ b/app.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
                     json.dumps(
                         {
                             "message": "diff",
-                            "login_user": login_players,
-                            "logout_user": logout_players,
+                            "login_players": login_players,
+                            "logout_players": logout_players,
                         }
                     )
                 )

--- a/app.py
+++ b/app.py
@@ -29,8 +29,8 @@ def fetch_login_players(mcr):
             break
         except:
             mcr.connect()
-
-    return players
+    # filter loading players
+    return [p for p in players if p['playeruid'] != '00000000']
 
 
 def diff_players(new_players, old_payers):


### PR DESCRIPTION
# Why
Until now, we had not taken into account that a player might be loading, so there were instances where we could not obtain the playeruid.
